### PR TITLE
Run docker as current uid:gid to avoid creating files as root

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -88,6 +88,7 @@ docker run \
 	--volume ${MAVEN_CACHE_HOST}:${MAVEN_CACHE_CONTAINER} \
 	--volume ${MAVEN_HOST}:${MAVEN_CONTAINER} \
 	--workdir $PROJECT2BUILD \
+	--user $(id -u):$(id -g) \
 	--name $DOCKER_CONTAINER $DOCKER_IMAGE \
 
 echo "building project"


### PR DESCRIPTION
Fixes #2.

This seems to work for our purposes (despite [bash complaining about an unknown user](https://github.com/binaryeq/jcompile/issues/2#issuecomment-1765520639)), after I fixed up the ownership of files:
- inside each project's `target` dir
- inside `.m2` Maven cache
