### PR TITLE
Enable parallel builds

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -16,7 +16,7 @@ TAG=$5
 RESULT_ROOT_FOLDER=$6
 
 # Make the container name unique to each process to enable parallel builds
-DOCKER_CONTAINER="$DOCKER_CONTAINER_BASENAME.$$"
+DOCKER_CONTAINER="${DOCKER_CONTAINER_BASENAME}__pid$$"
 
 TMP_LOG="build.$$.log"
 


### PR DESCRIPTION
Include the PID in the build log filename and docker container name, to enable multiple parallel runs of `docker-build-project.sh`. (Using separate containers is more isolated than reusing a single container for multiple builds with the same toolchain.)

Container names now look like:
```
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ docker ps -a
CONTAINER ID   IMAGE                           COMMAND       CREATED         STATUS         PORTS     NAMES
9f14285f4212   eclipse-temurin:8u372-b07-jdk   "/bin/bash"   5 seconds ago   Up 5 seconds             openjdk-8.0.372__pid1413110
```
