### PR TITLE
Work around high-value docker uid on `piccolo`

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -88,19 +88,18 @@ PROJECT2BUILD=${DATASET_CONTAINER}
 #docker stop $DOCKER_CONTAINER
 docker pull $DOCKER_IMAGE
 #docker start $DOCKER_CONTAINER
+# We no longer use '--user $(id -u):$(id -g)' since if --userns-remap is in force, that winds up creating restricted-perm files
+# under . at random intervals which we can't clean up from the host. See https://github.com/binaryeq/jcompile/pull/10#issuecomment-1771989895
 docker run \
 	-dit \
 	--volume ${WORKTREE_HOST}:${DATASET_CONTAINER} \
 	--volume ${MAVEN_CACHE_HOST}:${MAVEN_CACHE_CONTAINER} \
 	--volume ${MAVEN_HOST}:${MAVEN_CONTAINER} \
 	--workdir $PROJECT2BUILD \
-	--user $(id -u):$(id -g) \
 	--name $DOCKER_CONTAINER $DOCKER_IMAGE \
 
 echo "building project"
 docker exec -it $DOCKER_CONTAINER ${MAVEN_CONTAINER}/bin/mvn -Dmaven.repo.local=${MAVEN_CACHE_CONTAINER} -Drat.skip=true -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true clean package | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' | tee ${TMP_LOG}
-# Some files are written slightly later (see https://github.com/binaryeq/jcompile/pull/10#issuecomment-1771989895). Wait for them before chmodding.
-sleep 3
 # Some projects make files with restricted perms even if umask 0 is in force, and if --userns-remap is in force we otherwise wouldn't be able to delete them on the host afterwards.
 # Ignore "permission denied" on the top-level dir as it's owned by the host uid -- easier than trying to use wildcards to correctly get dotfiles and dotdirs.
 docker exec -it $DOCKER_CONTAINER chmod -R a+rwX .


### PR DESCRIPTION
On `piccolo`, docker adds 100000 to the uid and gid, which breaks permissions w.r.t. both the Maven cache and removing built targets afterwards on the host:
```
[whitewa@piccolo ~/code/jcompile]$ ls -ld /local/scratch/whitewa/TEST_LOCAL_DIR
drwxr-xrwx 2 whitewa others 4096 Oct 20 02:01 /local/scratch/whitewa/TEST_LOCAL_DIR
[whitewa@piccolo ~/code/jcompile]$ docker run -dit --userns=host --volume /local/scratch/whitewa/TEST_LOCAL_DIR:/TEST_LOCAL_DIR --user $(id -u):$(id -g) --name tim-test eclipse-temurin:8u372-b07-jdk
6a0c0af2cf06fdb5d383e2826558860fe959d81f84d889c243423e2b29bf2b48
[whitewa@piccolo ~/code/jcompile]$ docker exec -it tim-test bash
groups: cannot find name for group ID 23
I have no name!@6a0c0af2cf06:/$ ls -ld /TEST_LOCAL_DIR
drwxr-xrwx 2 nobody nogroup 4096 Oct 19 13:01 /TEST_LOCAL_DIR
I have no name!@6a0c0af2cf06:/$ echo abc > /TEST_LOCAL_DIR/def
I have no name!@6a0c0af2cf06:/$ ls -l !$
ls -l /TEST_LOCAL_DIR/def
-rw-r--r-- 1 1415 23 4 Oct 19 20:29 /TEST_LOCAL_DIR/def
I have no name!@6a0c0af2cf06:/$ exit
exit
[whitewa@piccolo ~/code/jcompile]$ ls -l /local/scratch/whitewa/TEST_LOCAL_DIR
total 4
-rw-r--r-- 1 101415 100023 4 Oct 20 09:29 def
```

Although https://docs.docker.com/engine/security/userns-remap/#disable-namespace-remapping-for-a-container says that you should be able to disable this by passing `--userns=host` to `docker run`, this had no effect for me 😞

With this in place, we get nearly as many jars built as on `wtwhite-vuw-vm` (663 vs. 676):
```
[whitewa@piccolo ~/code/jcompile]$ /usr/bin/time ./docker-build-all.sh 
--snip--
-------------------------------------
178.01user 132.58system 4:17:15elapsed 2%CPU (0avgtext+0avgdata 78064maxresident)k
320808inputs+24216376outputs (1684major+13910623minor)pagefaults 0swaps
[whitewa@piccolo ~/code/jcompile]$ ls jars/*/*.jar.error|wc -l
121
[whitewa@piccolo ~/code/jcompile]$ ls jars/*/*.jar|wc -l
663
```