### PR TITLE
Detect bytecode features

### DIFF
--- a/detect-bytecode-features.sh
+++ b/detect-bytecode-features.sh
@@ -4,7 +4,8 @@ case "$1" in
 	JEP181)
 		# JDK >= 11 uses "nests" to allow inner classes to access private members of outer classes directly, instead of creating synthetic methods in the outer class: https://openjdk.org/jeps/181
 		# A positive detection (exit code 0) means the *old* (JDK < 11) behaviour, since this is easier to test for.
-		javap -c -v "$2" | grep -E -A 3 'static .* access\$[0-9]+\(' | grep -q -E -w 'ACC_SYNTHETIC|Synthetic: true'
+		# (Why so complicated? Early javac versions (but not early ecj versions) add 'Synthetic: true' *after* the code; the first grep strips out the code, then sed "fattens" the blank line to avoid false positives.)
+		javap -c -v "$2" | grep -E '^(  [^ ]|    [^ ]|$)' | sed -Ee '/^$/{p;p;p}' | grep -E -A 4 'static .* access\$[0-9]+\(' | grep -q -E -w 'ACC_SYNTHETIC|Synthetic: true'
 		;;
 
 	JEP280)


### PR DESCRIPTION
A simple shell script to run `javap -c -v` on a class file to analyse it for various bytecode-level features. So far detects JEP181 and JEP280.

The exit code is 0 if the feature is *positively detected*, otherwise 1; there is no output on `stdout`. Note: For JEP181, a positive detection means the *old* behaviour (generation of synthetic methods); for JEP280, a positive detection means the *new* behaviour (special method calls to do in-place string concatenation):

```
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ ./detect-bytecode-features.sh JEP181 ~/code/jcompile/bytecode_features/JDK8/JEP181.class
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ echo $?
0
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ ./detect-bytecode-features.sh JEP181 ~/code/jcompile/bytecode_features/JDK11/JEP181.class
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ echo $?
1
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ ./detect-bytecode-features.sh JEP280 ~/code/jcompile/bytecode_features/JDK8/JEP280.class
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ echo $?
1
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ ./detect-bytecode-features.sh JEP280 ~/code/jcompile/bytecode_features/JDK11/JEP280.class
wtwhite@wtwhite-vuw-vm:~/code/jcompile-detect-bytecode-features$ echo $?
0
```
