### PR TITLE
Add 3 latest versions of `com.puppycrawl.tools:checkstyle` project

### DIFF
--- a/dataset.json
+++ b/dataset.json
@@ -267,6 +267,21 @@
 		"name":"jackson-core",
 		"tag":"jackson-core-2.14.2",
 		"jar":"jackson-core-2.14.2.jar"
+	},
+	{
+		"name":"checkstyle",
+		"tag":"checkstyle-10.12.4",
+		"jar":"checkstyle-10.12.4.jar"
+	},
+	{
+		"name":"checkstyle",
+		"tag":"checkstyle-10.12.3",
+		"jar":"checkstyle-10.12.3.jar"
+	},
+	{
+		"name":"checkstyle",
+		"tag":"checkstyle-10.12.2",
+		"jar":"checkstyle-10.12.2.jar"
 	}
 
 ]


### PR DESCRIPTION
`com.puppycrawl.tools:checkstyle` appears to be the successor to the original `checkstyle:checkstyle` project last updated in 2009 (see https://github.com/binaryeq/jcompile/issues/19#issuecomment-1791564068 and following comment).

Resolves #19.