### PR TITLE
Add `ALL_PROJECT_<proj>` and `ALL_COMPILER_<comp>` targets to build subsets only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # ALL_JAR_DONES is not filled out until after the include, but make takes the first goal as the default.
 all: all_defined_after_include
 
-generated_rules_for_all_jars.mk: dataset.json java-compilers.json
+generated_rules_for_all_jars.mk: dataset.json java-compilers.json docker-build-all.sh
 	echo "Regenerating make rules in $@ from $^..."
 	./docker-build-all.sh --output-make-rules > $@
 

--- a/docker-build-all.sh
+++ b/docker-build-all.sh
@@ -53,6 +53,8 @@ for row in $(echo "${compilers}" | jq -r '.[] | @base64'); do
 		if [ $FOR_MAKE = 1 ]
 		then
 			echo "ALL_JAR_DONES += $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
+			echo "ALL_PROJECT_$PROJECT_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
+			echo "ALL_COMPILER_$CONTAINER_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
 			echo "$JARS/$CONTAINER_NAME/$PROJECT_JAR.done:"
 			/usr/bin/echo -e '\t'./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "'$PREP_WORKTREE_CMD'" '&& touch $@'
 			echo


### PR DESCRIPTION
Also regenerate `generated_rules_for_all_jars.mk` whenever `docker-build-all.sh` changes.

Just adding prerequisites directly to targets one by one, instead of appending to a variable like for `ALL_JAR_DONES`, seems to work fine. Could probably change `ALL_JAR_DONES` to work the same way but I see little benefit.