### PR TITLE
Compile tests too but don't run them

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -127,6 +127,15 @@ echo ""
 if test -f "${WORKTREE_HOST}/target/${JAR_NAME}"; then
 	echo "SUCCESS! - copying /target/${JAR_NAME}  into ${RESULT_FOLDER}"
 	cp ${WORKTREE_HOST}/target/${JAR_NAME} ${RESULT_FOLDER}
+
+	# At least some projects also create a jar containing compiled tests -- get that too.
+	TEST_JAR_PATH="${WORKTREE_HOST}/target/${JAR_NAME%%.jar}-tests.jar"
+	if test -f $TEST_JAR_PATH; then
+		echo "Found tests jar $TEST_JAR_PATH, copying that also."
+		cp "$TEST_JAR_PATH" "$RESULT_FOLDER"
+	fi
+
+	# Gather some additional metadata
 	( cd "${WORKTREE_HOST}" && find target/generated-sources | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.generated-sources"	# Failure here creates a 0-length file, which is fine
 	( cd "${WORKTREE_HOST}" && find target -type f -name '*.class' | xargs "$DETECT_BYTECODE_FEATURES" | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.bytecode-features"
 else 


### PR DESCRIPTION
Resolves #48.

The main idea of changing `-Dmaven.test.skip=true` to `-DskipTests` gave successful compilation on an example project:

```
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ time make jars/openjdk-11.0.16/checkstyle-10.12.3.jar.done 
--snip--
SUCCESS! - copying /target/checkstyle-10.12.3.jar  into jars/openjdk-11.0.16
openjdk-11.0.16__pid1216068
openjdk-11.0.16__pid1216068

================================================


real	0m42.738s
user	0m53.025s
sys	0m6.711s
```

But although that resulted in more bytecode feature metadata being generated, the output jar looks to be unchanged compared to an earlier run (`23`):
```
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ ( cd runs/23/ && ls -l jars/openjdk-11.0.16/checkstyle-10.12.3* )
-rw-rw-r-- 1 wtwhite wtwhite 2076902 Nov 28 23:49 jars/openjdk-11.0.16/checkstyle-10.12.3.jar
-rw-rw-r-- 1 wtwhite wtwhite  179326 Nov 28 23:49 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.bytecode-features
-rw-rw-r-- 1 wtwhite wtwhite       0 Nov 28 23:49 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.done
-rw-rw-r-- 1 wtwhite wtwhite    1959 Nov 28 23:49 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.generated-sources
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ ls -l jars/openjdk-11.0.16/checkstyle-10.12.3*
-rw-rw-r-- 1 wtwhite wtwhite 2076902 Nov 29 09:55 jars/openjdk-11.0.16/checkstyle-10.12.3.jar
-rw-rw-r-- 1 wtwhite wtwhite 1384763 Nov 29 09:55 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.bytecode-features
-rw-rw-r-- 1 wtwhite wtwhite       0 Nov 29 09:55 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.done
-rw-rw-r-- 1 wtwhite wtwhite    1959 Nov 29 09:55 jars/openjdk-11.0.16/checkstyle-10.12.3.jar.generated-sources
```

How to get the tests into the same jar? Do we even want this?

Maybe we should create a separate `.tests.jar` file. Doing this via Maven is probably tricky (requiring automated messing with `pom.xml`, and it would be different depending on which plugin(s) were used to build the existing jar) so it would be easier to build this ourselves after running Maven.