### PR TITLE
Drop completely compatible rows when generating NEQ1

### DIFF
--- a/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AbstractClassOracle.java
+++ b/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AbstractClassOracle.java
@@ -86,7 +86,10 @@ public abstract class AbstractClassOracle implements ClassOracle {
                         .map(i -> groupAnonInnerClasses(classes.get(i).get(commonNamedClass), jars.get(i), parsedJarPaths.get(i).compiler(), parsedJarPaths.get(i).project(), jarMetadatas.get(i), scope))
                         .toList();
                 if (includeClassPair(zPaths.get(0), zPaths.get(1))) {
-                    classOracle.add(makeRow.apply(Pair.of(zPaths.get(0), zPaths.get(1))));
+                    R maybeRow = makeRow.apply(Pair.of(zPaths.get(0), zPaths.get(1)));  // makeRow() may still decide it doesn't want this row
+                    if (maybeRow != null) {
+                        classOracle.add(maybeRow);
+                    }
                 }
             }
         }

--- a/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AdjacentVersionSameArtifactAndCompilerClassOracle.java
+++ b/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AdjacentVersionSameArtifactAndCompilerClassOracle.java
@@ -34,7 +34,16 @@ public class AdjacentVersionSameArtifactAndCompilerClassOracle extends AbstractC
 
     private AdjacentVersionSameArtifactAndCompilerClassOracleRow makeRow(Pair<ZipPath, ZipPath> zPaths) {
         Preconditions.checkArgument(zPaths.getLeft().innerPath().equals(zPaths.getRight().innerPath()));
-        return new AdjacentVersionSameArtifactAndCompilerClassOracleRow(zPaths, currentJarPairRevApiJarComparer.compareClassVersions(zPaths.getLeft().innerPath()));
+
+        AdjacentVersionSameArtifactAndCompilerClassOracleRow row = new AdjacentVersionSameArtifactAndCompilerClassOracleRow(zPaths, currentJarPairRevApiJarComparer.compareClassVersions(zPaths.getLeft().innerPath()));
+        RevApiJarComparer.RevApiResult revApiResult = row.getRevApiResult();
+        if (revApiResult.source() == RevApiJarComparer.Severity.BREAKING || revApiResult.binary() == RevApiJarComparer.Severity.BREAKING || revApiResult.semantic() == RevApiJarComparer.Severity.BREAKING) {
+            // RevApi thinks these classes are incompatible: Keep this row
+            return row;
+        } else {
+            // RevApi thinks these classes are compatible: Drop this row
+            return null;
+        }
     }
 
     /**

--- a/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AdjacentVersionSameArtifactAndCompilerClassOracleRow.java
+++ b/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AdjacentVersionSameArtifactAndCompilerClassOracleRow.java
@@ -13,6 +13,10 @@ public class AdjacentVersionSameArtifactAndCompilerClassOracleRow extends ClassO
         this.revApiResult = revApiResult;
     }
 
+    public RevApiJarComparer.RevApiResult getRevApiResult() {
+        return revApiResult;
+    }
+
     @Override
     public void printRow(PrintStream out) {
         out.println(String.join("\t", Stream.of(


### PR DESCRIPTION
Addresses #73 once NEQ1 has been rerun.

We lose most of the NEQ1 rows on the example dataset, as expected:
```
wtwhite@wtwhite-vuw-vm:~/code/jcompile/oracle-construction$ time java -cp target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.AdjacentVersionSameArtifactAndCompilerClassOracle fixed_small_jars_with_tests > fixed_small_jars_with_tests_AdjacentVersionSameArtifactAndCompiler_dropcompatrows.txt
Found dataset.json at ../dataset.json
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/json-20211205.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/json-20220320.jar
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/json-20220320.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/json-20220924.jar
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/json-20220924.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/json-20230227.jar
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/json-20230227.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/json-20230618.jar
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/checkstyle-10.12.2.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/checkstyle-10.12.3.jar
analysing: fixed_small_jars_with_tests/openjdk-11.0.19/checkstyle-10.12.3.jar vs fixed_small_jars_with_tests/openjdk-11.0.19/checkstyle-10.12.4.jar
--snip--
real	0m57.498s
user	1m5.972s
sys	0m7.698s
wtwhite@wtwhite-vuw-vm:~/code/jcompile/oracle-construction$ wc -l fixed_small_jars_with_tests_AdjacentVersionSameArtifactAndCompiler_dropcompatrows.txt
1604 fixed_small_jars_with_tests_AdjacentVersionSameArtifactAndCompiler_dropcompatrows.txt
wtwhite@wtwhite-vuw-vm:~/code/jcompile/oracle-construction$ wc -l fixed_small_jars_with_tests_AdjacentVersionSameArtifactAndCompiler_correctprojectnames.txt 
22112 fixed_small_jars_with_tests_AdjacentVersionSameArtifactAndCompiler_correctprojectnames.txt
```
