### PR TITLE
Add Oracle compilers

### DIFF
--- a/java-compilers.json
+++ b/java-compilers.json
@@ -103,5 +103,9 @@
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.32.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0"
+	},
+	{
+		"image":"container-registry.oracle.com/java/jdk:11.0.19-ol8-amd64",
+		"name":"oraclejdk-11.0.19"
 	}
 ]

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -105,7 +105,19 @@
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0"
 	},
 	{
+		"image":"container-registry.oracle.com/java/jdk:8u371-ol8-amd64",
+		"name":"oraclejdk-8.0.371"
+	},
+	{
 		"image":"container-registry.oracle.com/java/jdk:11.0.19-ol8-amd64",
 		"name":"oraclejdk-11.0.19"
+	},
+	{
+		"image":"container-registry.oracle.com/java/jdk:17.0.7-ol8-amd64",
+		"name":"oraclejdk-17.0.7"
+	},
+	{
+		"image":"container-registry.oracle.com/java/jdk:20.0.1-ol8-amd64",
+		"name":"oraclejdk-20.0.1"
 	}
 ]


### PR DESCRIPTION
Resolves #80.

The Oracle JDK versions added correspond as closely as possible to (a subset of) existing OpenJDK versions in `java-compiler.json` -- the only mismatch is that Oracle JDK has no version 8.0.372, so 8.0.371 was added instead.

Docker images for these Oracle compilers are available from https://container-registry.oracle.com/ords/ocr/ba/java/jdk, and downloading them with `docker pull` requires:

1. Creating an Oracle account
2. Going to https://container-registry.oracle.com/ords/ocr/ba/java/jdk
3. Logging in with your account
4. Accepting the Oracle Standard Terms on the webpage (forgetting this step will mean that `docker login` appears to succeed, but `docker pull` will fail)
5. Running `docker login container-registry.oracle.com` and supplying your Oracle username and password
6. Running, e.g., `docker pull container-registry.oracle.com/java/jdk:11.0.19-ol8-amd64`
