### PR TITLE
Add debug mode compilers

### DIFF
--- a/inject-debug-mode-compiler.pl
+++ b/inject-debug-mode-compiler.pl
@@ -1,0 +1,54 @@
+#!/usr/bin/perl -i.bak
+
+# Usage: inject-debug-mode-compiler path/to/pom.xml
+#        inject-debug-mode-compiler path/to/dir-with-pom
+#
+# In the second case, where the argument is a directory, "/pom.xml" will be auto-appended.
+# pom.xml will be *replaced*, with the old version backed up to pom.xml.bak.
+
+use strict;
+use warnings;
+
+my $v = shift;
+my $inBuild = 0;
+my $success = 0;
+
+print STDERR "ARGV: ", join(',', @ARGV), "\n";
+die "Must specify pom.xml or path to it!" if !@ARGV;
+if (-d $ARGV[0]) {
+	print STDERR "Auto-appending /pom.xml to dir path $ARGV[0]\n";
+	$ARGV[0] .= '/pom.xml';		# Simplifies running from build-docker-project.sh
+}
+
+while (<>) {
+	print;
+
+	if (m|\A\s*<(/?)build>\s*\z|) {
+		$inBuild = ($1 ne '/');
+	}
+
+	if ($inBuild && /\A(\s*)<plugins>\s*\z/) {
+		# Some projects will refuse to build if the indentation is wrong!
+		print <<THE_END;
+$1  <!-- Following plugin added automatically by $0, based on https://stackoverflow.com/a/33165304/47984 -->
+$1  <plugin>
+$1    <artifactId>maven-compiler-plugin</artifactId>
+$1    <version>3.6.0</version>
+$1    <configuration>
+$1      <compilerArgs>
+$1        <arg>-g</arg>
+$1      </compilerArgs>
+$1    </configuration>
+$1  </plugin>
+
+THE_END
+		$success = 1;
+	}
+}
+
+if (!$success) {
+	print STDERR "Could not find <plugins>!";
+	exit 1;
+}
+
+exit 0;

--- a/inject-debug-mode-compiler.pl
+++ b/inject-debug-mode-compiler.pl
@@ -9,7 +9,6 @@
 use strict;
 use warnings;
 
-my $v = shift;
 my $inBuild = 0;
 my $success = 0;
 

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -119,5 +119,25 @@
 	{
 		"image":"container-registry.oracle.com/java/jdk:20.0.1-ol8-amd64",
 		"name":"oraclejdk-20.0.1"
+	},
+	{
+		"image":"eclipse-temurin:8u372-b07-jdk",
+		"name":"openjdk-debug-8.0.372",
+		"prep_worktree_cmd":"./inject-debug-mode-compiler.pl"
+	},
+	{
+		"image":"eclipse-temurin:11.0.19_7-jdk",
+		"name":"openjdk-debug-11.0.19",
+		"prep_worktree_cmd":"./inject-debug-mode-compiler.pl"
+	},
+	{
+		"image":"eclipse-temurin:17.0.7_7-jdk",
+		"name":"openjdk-debug-17.0.7",
+		"prep_worktree_cmd":"./inject-debug-mode-compiler.pl"
+	},
+	{
+		"image":"eclipse-temurin:20.0.1_9-jdk",
+		"name":"openjdk-debug-20.0.1",
+		"prep_worktree_cmd":"./inject-debug-mode-compiler.pl"
 	}
 ]

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -45,6 +45,21 @@ function transform(pomJson, ancestors) {
 	}
 }
 
+function findOrMakeElement(root, elemName) {
+	if (!('elements' in root)) {
+		root.elements = [];
+	}
+
+	let existingElem = root.elements.find((e) => e.type === 'element' && e.name === elemName);
+	if (existingElem) {
+		return existingElem;
+	} else {
+		const elem = { type: 'element', name: elemName };
+		root.elements.push({ type: 'element', name: elemName });
+		return elem;
+	}
+}
+
 function inject() {
 	console.warn(`Will inject ${existingPluginsListsWithoutCompilerPlugin.length} maven-compiler-plugin plugins into existing <plugins> elements that don't have them yet:`);
 	for (const e of existingPluginsListsWithoutCompilerPlugin) {
@@ -88,5 +103,15 @@ function inject() {
 				]
 			}
 		] });
+	}
+
+	console.warn(`Will modify ${existingCompilerPlugins.length} maven-compiler-plugin <plugin> elements by adding '-g' arguments:`);
+	for (const e of existingCompilerPlugins) {
+		const configuration = findOrMakeElement(e, 'configuration');
+		const compilerArgs = findOrMakeElement(e, 'compilerArgs');
+		if (!('elements' in compilerArgs)) {
+			compilerArgs.elements = [];
+		}
+		compilerArgs.elements.push({ type: 'element', name: 'arg', elements: [{ type: 'text', text: '-g' }] });
 	}
 }

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -24,7 +24,7 @@ function transform(pomJson, ancestors) {
 	if (pomJson.type === 'element' && pomJson.name === 'artifactId' && ancestors.slice(0, 3).every((e) => e.type === 'element') && ancestors.slice(0, 3).map((e) => e.name).join('>') === 'plugin>plugins>build') {
 		if (pomJson?.elements?.[0]?.text === 'maven-compiler-plugin') {
 			console.warn(`Found existing maven-compiler-plugin element!`);
-			existingCompilerPlugins.push(pomJson);
+			existingCompilerPlugins.push(ancestors[0]);
 			const iParentPluginsList = existingPluginsListsWithoutCompilerPlugin.indexOf(ancestors[1]);
 			if (iParentPluginsList !== -1) {
 				console.warn(`Removing its parent from the list of <plugins> elements without a compiler plugin.`);
@@ -46,14 +46,18 @@ function transform(pomJson, ancestors) {
 }
 
 function findOrMakeElement(root, elemName) {
+	console.warn(`findOrMakeElement(root=`, root, `, elemName=${elemName}) called.`);		//DEBUG
 	if (!('elements' in root)) {
+		console.warn(`findOrMakeElement(): Adding nonexistent 'elements' array`);		//DEBUG
 		root.elements = [];
 	}
 
 	let existingElem = root.elements.find((e) => e.type === 'element' && e.name === elemName);
 	if (existingElem) {
+		console.warn(`findOrMakeElement(): Found existing '${elemName}', returning it.`);		//DEBUG
 		return existingElem;
 	} else {
+		console.warn(`findOrMakeElement(): Did not find any existing '${elemName}', adding a new one.`);		//DEBUG
 		const elem = { type: 'element', name: elemName };
 		root.elements.push({ type: 'element', name: elemName });
 		return elem;
@@ -108,7 +112,7 @@ function inject() {
 	console.warn(`Will modify ${existingCompilerPlugins.length} maven-compiler-plugin <plugin> elements by adding '-g' arguments:`);
 	for (const e of existingCompilerPlugins) {
 		const configuration = findOrMakeElement(e, 'configuration');
-		const compilerArgs = findOrMakeElement(e, 'compilerArgs');
+		const compilerArgs = findOrMakeElement(configuration, 'compilerArgs');
 		if (!('elements' in compilerArgs)) {
 			compilerArgs.elements = [];
 		}

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -5,15 +5,24 @@ const fs = require("fs");
 const existingPluginsListsWithoutCompilerPlugin = [];
 const existingCompilerPlugins = [];
 
-console.warn(`${process.argv[1]} starting.`);
-const stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
+let inFName = process.argv[2];
+if (fs.lstatSync(inFName).isDirectory()) {
+	inFName += '/pom.xml';
+}
+
+const renamedInFName = inFName + ".bak";
+console.warn(`${process.argv[1]} starting. Will process ${inFName}, renaming the original to ${renamedInFName}.bak.`);
+fs.renameSync(inFName, renamedInFName);	// Let exception terminate us if a problem occurs
+
+//const stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
+const stdinBuffer = fs.readFileSync(renamedInFName);
 const stdin = stdinBuffer.toString();
 
 let pomJson = convert.xml2js(stdin, { compact: false, spaces: 2 });
 transform(pomJson, []);
 inject();
 let newPomXml = convert.js2xml(pomJson, { compact: false, spaces: 2 });
-console.log(newPomXml);
+fs.writeFileSync(inFName, newPomXml);
 console.warn(`${process.argv[1]} finished.`);
 
 function transform(pomJson, ancestors) {

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -88,53 +88,34 @@ function forEachElement(root, elemNames, cb) {
 	}
 }
 
+function makeElem(name, ...elements) {
+	return { type: 'element', name, elements };
+}
+
+function makeText(text) {
+	return { type: 'text', text };
+}
+
 function inject() {
 	console.warn(`Will inject ${existingPluginsListsWithoutCompilerPlugin.length} maven-compiler-plugin plugins into existing <plugins> elements that don't have them yet:`);
 	for (const e of existingPluginsListsWithoutCompilerPlugin) {
-		e.elements.push(comment(), {
-			type: 'element',
-			name: 'plugin',
-			elements: [
-				{
-					type: 'element',
-					name: 'artifactId',
-					elements: [
-						{
-							type: 'text',
-							text: 'maven-compiler-plugin'
-						}
-					]
-				},
-				{
-					type: 'element',
-					name: 'configuration',
-					elements: [
-						{
-							type: 'element',
-							name: 'compilerArgs',
-							elements: [
-								{
-									type: 'element',
-									name: 'arg',
-									elements: [
-										{
-											type: 'text',
-											text: '-g'
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		});
+		e.elements.push(
+			comment(),
+			makeElem('plugin',
+				makeElem('artifactId', makeText('maven-compiler-plugin')),
+				makeElem('configuration',
+					makeElem('compilerArgs',
+						makeElem('arg', makeText('-g'))
+					)
+				)
+			)
+		);
 	}
 
 	console.warn(`Will modify ${existingCompilerPlugins.length} maven-compiler-plugin <plugin> elements by adding '-g' arguments:`);
 
 	function addHyphenG(e) {
-		const commentHolder = { commented: false };		// Will be set true by the call to findOrMakeElement() that needs to add an element
+		const commentHolder = { commented: false };		// Will be set true by the first call to findOrMakeElement() that needs to add an element
 		const configuration = findOrMakeElement(e, 'configuration', commentHolder);
 		const compilerArgs = findOrMakeElement(configuration, 'compilerArgs', commentHolder);
 		if (!('elements' in compilerArgs)) {
@@ -143,7 +124,7 @@ function inject() {
 		if (!commentHolder.commented) {
 			compilerArgs.elements.push(comment());
 		}
-		compilerArgs.elements.push({ type: 'element', name: 'arg', elements: [{ type: 'text', text: '-g' }] });
+		compilerArgs.elements.push(makeElem('arg', makeText('-g')));
 	}
 
 	for (const e of existingCompilerPlugins) {

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -91,46 +91,44 @@ function forEachElement(root, elemNames, cb) {
 function inject() {
 	console.warn(`Will inject ${existingPluginsListsWithoutCompilerPlugin.length} maven-compiler-plugin plugins into existing <plugins> elements that don't have them yet:`);
 	for (const e of existingPluginsListsWithoutCompilerPlugin) {
-		e.elements.push(comment(), { type: 'element', name: 'plugin', elements: [
-			{
-				type: 'element',
-				name: 'plugin',
-				elements: [
-					{
-						type: 'element',
-						name: 'artifactId',
-						elements: [
-							{
-								type: 'text',
-								text: 'maven-compiler-plugin'
-							}
-						]
-					},
-					{
-						type: 'element',
-						name: 'configuration',
-						elements: [
-							{
-								type: 'element',
-								name: 'compilerArgs',
-								elements: [
-									{
-										type: 'element',
-										name: 'arg',
-										elements: [
-											{
-												type: 'text',
-												text: '-g'
-											}
-										]
-									}
-								]
-							}
-						]
-					}
-				]
-			}
-		] });
+		e.elements.push(comment(), {
+			type: 'element',
+			name: 'plugin',
+			elements: [
+				{
+					type: 'element',
+					name: 'artifactId',
+					elements: [
+						{
+							type: 'text',
+							text: 'maven-compiler-plugin'
+						}
+					]
+				},
+				{
+					type: 'element',
+					name: 'configuration',
+					elements: [
+						{
+							type: 'element',
+							name: 'compilerArgs',
+							elements: [
+								{
+									type: 'element',
+									name: 'arg',
+									elements: [
+										{
+											type: 'text',
+											text: '-g'
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		});
 	}
 
 	console.warn(`Will modify ${existingCompilerPlugins.length} maven-compiler-plugin <plugin> elements by adding '-g' arguments:`);

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -1,0 +1,32 @@
+const convert = require('xml-js');
+const fs = require("fs");
+
+console.warn("Starting.");
+const stdinBuffer = fs.readFileSync(0); // STDIN_FILENO = 0
+const stdin = stdinBuffer.toString();
+
+let pomJson = convert.xml2js(stdin, { compact: false, spaces: 2 });
+//const newPomJson = transform(pomJson, []);
+console.warn(`BEFORE: pomJson=`, pomJson);
+transform(pomJson, []);
+console.warn(`AFTER: pomJson=`, pomJson);
+const newPomJson = pomJson;		//HACK
+let newPomXml = convert.js2xml(newPomJson, { compact: false, spaces: 2 });
+console.log(newPomXml);
+console.warn("Finished.");
+
+function transform(pomJson, ancestors) {
+	//console.warn(`transform(pomJson=`, pomJson, `, ancestors=[${ancestors.map((e) => e.name).join(', ')}]) called.`);		//DEBUG
+	if (pomJson.type === 'element' && pomJson.name === 'artifactId' && ancestors.slice(0, 3).every((e) => e.type === 'element') && ancestors.slice(0, 3).map((e) => e.name).join('>') === 'plugin>plugins>build') {
+		if (pomJson?.elements?.[0]?.text === 'maven-compiler-plugin') {
+			console.warn(`Found existing maven-compiler-plugin element!`);
+			//TODO
+		}
+	}
+
+	if ('elements' in pomJson) {
+		for (const e of pomJson.elements) {
+			transform(e, [pomJson, ...ancestors]);
+		}
+	}
+}

--- a/tools/inject-debug-mode-compiler.js
+++ b/tools/inject-debug-mode-compiler.js
@@ -1,4 +1,5 @@
 const process = require('process');
+const child_process = require('child_process');
 const convert = require('xml-js');
 const fs = require("fs");
 
@@ -23,6 +24,9 @@ transform(pomJson, []);
 inject();
 let newPomXml = convert.js2xml(pomJson, { compact: false, spaces: 2 });
 fs.writeFileSync(inFName, newPomXml);
+const dir = inFName.indexOf('/')  == -1 ? '.' : inFName.replace(/\/[^/]*$/, '');
+console.warn(`${process.argv[1]} running 'mvn tidy:pom' in dir ${dir}...`);
+child_process.execSync('mvn tidy:pom', { cwd: dir, stdio: 'inherit' });		// Otherwise the pom.xml formatting may be 'wrong', which some projects will complain about
 console.warn(`${process.argv[1]} finished.`);
 
 function transform(pomJson, ancestors) {

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "inject-debug-mode-compiler",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "inject-debug-mode-compiler",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    }
+  },
+  "dependencies": {
+    "sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "inject-debug-mode-compiler",
+  "version": "1.0.0",
+  "description": "Used internally by docker-build-project.sh",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Tim White",
+  "license": "ISC",
+  "dependencies": {
+    "xml-js": "^1.6.11"
+  }
+}


### PR DESCRIPTION
Resolves #81.

First test run using `inject-debug-mode-compiler.pl` to add the `-g` option to `checkstyle-10.12.3` produces a slightly larger jar:

```
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ ls -ltra jars/openjdk-debug-20.0.1/checkstyle-10.12.3*
-rw-rw-r-- 1 wtwhite wtwhite 2094082 Jun 14 14:35 jars/openjdk-debug-20.0.1/checkstyle-10.12.3.jar
-rw-rw-r-- 1 wtwhite wtwhite 3842430 Jun 14 14:35 jars/openjdk-debug-20.0.1/checkstyle-10.12.3-tests.jar
-rw-rw-r-- 1 wtwhite wtwhite     826 Jun 14 14:35 jars/openjdk-debug-20.0.1/checkstyle-10.12.3.jar.generated-sources
-rw-rw-r-- 1 wtwhite wtwhite 1384763 Jun 14 14:35 jars/openjdk-debug-20.0.1/checkstyle-10.12.3.jar.bytecode-features
-rw-rw-r-- 1 wtwhite wtwhite       0 Jun 14 14:35 jars/openjdk-debug-20.0.1/checkstyle-10.12.3.jar.done
wtwhite@wtwhite-vuw-vm:~/code/jcompile$ ^-debug
ls -ltra jars/openjdk-20.0.1/checkstyle-10.12.3*
-rw-rw-r-- 1 wtwhite wtwhite 2093468 Jun 13 18:40 jars/openjdk-20.0.1/checkstyle-10.12.3.jar
-rw-rw-r-- 1 wtwhite wtwhite 3842430 Jun 13 18:40 jars/openjdk-20.0.1/checkstyle-10.12.3-tests.jar
-rw-rw-r-- 1 wtwhite wtwhite     826 Jun 13 18:40 jars/openjdk-20.0.1/checkstyle-10.12.3.jar.generated-sources
-rw-rw-r-- 1 wtwhite wtwhite 1384763 Jun 13 18:41 jars/openjdk-20.0.1/checkstyle-10.12.3.jar.bytecode-features
-rw-rw-r-- 1 wtwhite wtwhite       0 Jun 13 18:41 jars/openjdk-20.0.1/checkstyle-10.12.3.jar.done
```
