### PR TITLE
Add 4 OpenJDK compilers with debugging turned off

### DIFF
--- a/docker-build-all.sh
+++ b/docker-build-all.sh
@@ -33,9 +33,10 @@ for row in $(echo "${compilers}" | jq -r '.[] | @base64'); do
     CONTAINER_NAME="$(_jq '.name')"
     IMAGE="$(_jq '.image')"
     PREP_WORKTREE_CMD="$(_jq '.prep_worktree_cmd + '\"\")"
+    EXTRA_MVN_ARGS="$(_jq '.extra_mvn_args + '\"\")"
 
    	#echo "container name: ${CONTAINER_NAME}"
-   	echo "# ---- compiling projects using: ${IMAGE} then ${PREP_WORKTREE_CMD:-(nothing further)} -----"
+   	echo "# ---- compiling projects using: ${IMAGE} with extra mvn args '$EXTRA_MVN_ARGS' then ${PREP_WORKTREE_CMD:-(nothing further)} -----"
    	#echo ""
 
     for row2 in $(echo "${projects}" | jq -r '.[] | @base64'); do
@@ -56,10 +57,10 @@ for row in $(echo "${compilers}" | jq -r '.[] | @base64'); do
 			echo "ALL_PROJECT_$PROJECT_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
 			echo "ALL_COMPILER_$CONTAINER_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
 			echo "$JARS/$CONTAINER_NAME/$PROJECT_JAR.done:"
-			/usr/bin/echo -e '\t'./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "'$PREP_WORKTREE_CMD'" '&& touch $@'
+			/usr/bin/echo -e '\t'./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "'$PREP_WORKTREE_CMD'" "'$EXTRA_MVN_ARGS'" '&& touch $@'
 			echo
 		else
-			$ECHO_IF_DRY_RUN sh ./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "$SQUOTE$PREP_WORKTREE_CMD$SQUOTE"
+			$ECHO_IF_DRY_RUN sh ./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "$SQUOTE$PREP_WORKTREE_CMD$SQUOTE" "$SQUOTE$EXTRA_MVN_ARGS$SQUOTE"
 		fi
 	done
 	echo "# -------------------------------------"

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -119,5 +119,25 @@
 	{
 		"image":"container-registry.oracle.com/java/jdk:20.0.1-ol8-amd64",
 		"name":"oraclejdk-20.0.1"
+	},
+	{
+		"image":"eclipse-temurin:8u372-b07-jdk",
+		"name":"openjdk-nodebug-8.0.372",
+		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+	},
+	{
+		"image":"eclipse-temurin:11.0.19_7-jdk",
+		"name":"openjdk-nodebug-11.0.19",
+		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+	},
+	{
+		"image":"eclipse-temurin:17.0.7_7-jdk",
+		"name":"openjdk-nodebug-17.0.7",
+		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+	},
+	{
+		"image":"eclipse-temurin:20.0.1_9-jdk",
+		"name":"openjdk-nodebug-20.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.debug=false"
 	}
 ]


### PR DESCRIPTION
Resolves #81 "backwards" -- it turns out that, although `javac` leaves debug information out by default, Maven turns debugging *on* by default, so we need to turn it off:

https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug

Also, this can be done from the `mvn` command very simply with `-Dmaven.compiler.debug=false`, so we don't need the whole complicated approach of #83 of finding every `maven-compiler-plugin` in the POM (including inside and outside of `<execution>`s, etc.) and adding `<compilerArgs><arg>-g</arg></compilerArgs>` to them. (That machinery may still be useful in improving the existing ECJ compiler injection though -- which currently uses a brittle regex-based approach.)