### PR TITLE
Exclude records with identical top-level classes, even if their AICs differ

### DIFF
--- a/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AbstractClassOracle.java
+++ b/oracle-construction/src/main/java/nz/ac/wgtn/shadedetector/jcompile/oracles/AbstractClassOracle.java
@@ -156,7 +156,19 @@ public abstract class AbstractClassOracle implements ClassOracle {
 
     // whether to include this (named) class reference in the oracle
     private boolean includeClassPair(ZipPath zpath1, ZipPath zpath2) throws IOException, URISyntaxException {
-        assert ! zpath1.outerPath().toString().equals(zpath2.outerPath().toString()) ;
+        assert !zpath1.outerPath().toString().equals(zpath2.outerPath().toString());
+        // Now we consider only the classes themselves, not their AICs
+        //return areClassesOrTheirAicsDifferent(zpath1, zpath2);
+        return areClassesDifferent(zpath1, zpath2);
+    }
+
+    private boolean areClassesDifferent(ZipPath zpath1, ZipPath zpath2) throws IOException, URISyntaxException {
+        byte[] content1 = read(zpath1.outerPath(), zpath1.innerPath());
+        byte[] content2 = read(zpath2.outerPath(), zpath2.innerPath());
+        return !Arrays.equals(content1, content2);
+    }
+
+    private boolean areClassesOrTheirAicsDifferent(ZipPath zpath1, ZipPath zpath2) throws IOException, URISyntaxException {
         if (!zpath1.allInnerPaths().equals(zpath2.allInnerPaths())) {
             return true;
         }


### PR DESCRIPTION
Per @jensdietrich's email request. This results in there being 477 fewer `EQ.tsv` records:
```
wtwhite@wtwhite-vuw-vm:~/code/jcompile/runs/33_with_oracle_and_nodebug$ wc -l EQ.dotonly*.tsv
   320854 EQ.dotonly.dontcompareAICs.tsv
   321331 EQ.dotonly.tsv
   642185 total
```
