### PR TITLE
Automate NEQ1 creation

### DIFF
--- a/Makefile.NEQ1
+++ b/Makefile.NEQ1
@@ -1,0 +1,16 @@
+# Makefile to (re)build NEQ1 and its prerequisites.
+# Run this from a subdirectory of runs/ that contains a jars/EQ directory already.
+
+JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
+
+all: NEQ1.tsv
+
+NEQ1.tsv: all.BREAKING all.POTENTIALLY_BREAKING
+	time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.AdjacentVersionSameArtifactAndCompilerClassOracle jars > $@
+
+generated_rules_for_NEQ1_revapi.mk:
+	echo "Regenerating make rules in $@..."
+	time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.AdjacentVersionSameArtifactAndCompilerJarOracle jars > jars_for_NEQ1.tsv
+	$(JCOMPILE_ROOT)/make-revapi-runner.sh < jars_for_NEQ1.tsv > $@
+
+include generated_rules_for_NEQ1_revapi.mk

--- a/make-revapi-runner.sh
+++ b/make-revapi-runner.sh
@@ -1,18 +1,16 @@
 #!/bin/sh
 
-# Input on stdin should consist of the logging output of AdjacentVersionSameArtifactAndCompilerClassOracle (lines of the form "analysing XYZ.jar vs ABC.jar", or "XYZ.jar\tABC.jar").
+# Input on stdin should consist of the logging output of AdjacentVersionSameArtifactAndCompilerJarOracle (lines of the form "analysing XYZ.jar vs ABC.jar", or "XYZ.jar\tABC.jar").
 # Outputs a Makefile to stdout that will run revapi on each mentioned pair of jars and store the JSON output in a file that mentions both jars' versions.
-# Optionally supply a minimum severity (EQUIVALENT, NON_BREAKING, POTENTIALLY_BREAKING or BREAKING (the default)) on the command line.
+# Of the possible minimum severities (EQUIVALENT, NON_BREAKING, POTENTIALLY_BREAKING or BREAKING (the default)), we only care about BREAKING and POTENTIALLY_BREAKING.
 
-MINSEVERITY="${1:-BREAKING}"
 REVAPI_BASE_CMD="revapi.sh --extensions=org.revapi:revapi-java:0.28.1,org.revapi:revapi-reporter-json:0.5.0 -Drevapi.reporter.json.minSeverity"		# Must be followed by, e.g., "=BREAKING"
 
-echo "all:"		# Make defaults to first goal
+echo "all: all.BREAKING all.POTENTIALLY_BREAKING"		# Make defaults to first goal
 echo
-echo "MINSEVERITY := $MINSEVERITY"		# So the value passed to this script becomes the default, but it can be overridden at make time
 echo "JCOMPILE_ROOT := $(git rev-parse --show-toplevel)"
 echo
 echo "%.tsv: %.json"
 /bin/echo -e "\\t\$(JCOMPILE_ROOT)/summarise-revapi-json-to-tsv.sh < \$< > \$@"
 echo
-perl -lne 'if (m%^(?:analysing: )?(\S+)\.jar(?: vs |\t)(\S+/([^/]+))\.jar%) { my $bn = "$1__vs__$3.revapi.\$(MINSEVERITY)"; print "$bn.json:\n\t'"$REVAPI_BASE_CMD"'=\$(MINSEVERITY) --old=$1.jar --new=$2.jar -Drevapi.reporter.json.output=\$\@\nall: $bn.tsv\n"; }'
+perl -lne 'sub f($) { my ($MINSEVERITY) = @_; if (m%^(?:analysing: )?(\S+)\.jar(?: vs |\t)(\S+/([^/]+))\.jar%) { my $bn = "$1__vs__$3.revapi.$MINSEVERITY"; print "$bn.json:\n\t'"$REVAPI_BASE_CMD"'=$MINSEVERITY --old=$1.jar --new=$2.jar -Drevapi.reporter.json.output=\$\@\nall.$MINSEVERITY: $bn.tsv\n"; } } f("BREAKING"); f("POTENTIALLY_BREAKING");'

--- a/make-revapi-runner.sh
+++ b/make-revapi-runner.sh
@@ -1,32 +1,18 @@
 #!/bin/sh
 
-# Input on stdin should consist of the logging output of AdjacentVersionSameArtifactAndCompilerClassOracle (lines of the form "analysing XYZ.jar vs ABC.jar").
-# Outputs a shell script to stdout that will run revapi on each mentioned pair of jars and store the JSON output in a file that mentions both jars' versions.
+# Input on stdin should consist of the logging output of AdjacentVersionSameArtifactAndCompilerClassOracle (lines of the form "analysing XYZ.jar vs ABC.jar", or "XYZ.jar\tABC.jar").
+# Outputs a Makefile to stdout that will run revapi on each mentioned pair of jars and store the JSON output in a file that mentions both jars' versions.
 # Optionally supply a minimum severity (EQUIVALENT, NON_BREAKING, POTENTIALLY_BREAKING or BREAKING (the default)) on the command line.
-# If the first argument is --output-makefile, a Makefile will be written instead of a shell script. This can make continuing incomplete runs and running in parallel easier.
-
-if [ "$1" = "--output-makefile" ]
-then
-	MODE=make
-	shift
-else
-	MODE=script
-fi
 
 MINSEVERITY="${1:-BREAKING}"
 REVAPI_BASE_CMD="revapi.sh --extensions=org.revapi:revapi-java:0.28.1,org.revapi:revapi-reporter-json:0.5.0 -Drevapi.reporter.json.minSeverity"		# Must be followed by, e.g., "=BREAKING"
 
-if [ $MODE = make ]
-then
-	echo "all:"		# Make defaults to first goal
-	echo
-	echo "MINSEVERITY := $MINSEVERITY"		# So the value passed to this script becomes the default, but it can be overridden at make time
-	echo "JCOMPILE_ROOT := $(git rev-parse --show-toplevel)"
-	echo
-	echo "%.tsv: %.json"
-	/bin/echo -e "\\t\$(JCOMPILE_ROOT)/summarise-revapi-json-to-tsv.sh < \$< > \$@"
-	echo
-	perl -lne 'if (m%^(?:analysing: )?(\S+)\.jar(?: vs |\t)(\S+/([^/]+))\.jar%) { my $bn = "$1__vs__$3.revapi.\$(MINSEVERITY)"; print "$bn.json:\n\t'"$REVAPI_BASE_CMD"'=\$(MINSEVERITY) --old=$1.jar --new=$2.jar -Drevapi.reporter.json.output=\$\@\nall: $bn.tsv\n"; }'
-else
-	perl -lne 'if (m%^(?:analysing: )?(\S+)\.jar(?: vs |\t)(\S+/([^/]+))\.jar%) { print "'"$REVAPI_BASE_CMD=$MINSEVERITY"' --old=$1.jar --new=$2.jar -Drevapi.reporter.json.output=$1__vs__$3.revapi.'$MINSEVERITY'.json"; }'
-fi
+echo "all:"		# Make defaults to first goal
+echo
+echo "MINSEVERITY := $MINSEVERITY"		# So the value passed to this script becomes the default, but it can be overridden at make time
+echo "JCOMPILE_ROOT := $(git rev-parse --show-toplevel)"
+echo
+echo "%.tsv: %.json"
+/bin/echo -e "\\t\$(JCOMPILE_ROOT)/summarise-revapi-json-to-tsv.sh < \$< > \$@"
+echo
+perl -lne 'if (m%^(?:analysing: )?(\S+)\.jar(?: vs |\t)(\S+/([^/]+))\.jar%) { my $bn = "$1__vs__$3.revapi.\$(MINSEVERITY)"; print "$bn.json:\n\t'"$REVAPI_BASE_CMD"'=\$(MINSEVERITY) --old=$1.jar --new=$2.jar -Drevapi.reporter.json.output=\$\@\nall: $bn.tsv\n"; }'


### PR DESCRIPTION
If the jars built for `EQ.tsv` are already present in `jars/EQ`, it's now possible to completely build `NEQ1.tsv`, including all needed `revapi` runs, using:

```
make -f ../../Makefile.NEQ1
```

Adding, e.g., `-j 4` will parallelise this 4x.
