### PR TITLE
Force target bytecode version to match compiler major JDK version with `-Dmaven.compiler.debug=...`

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -123,7 +123,7 @@ echo "building project"
 # "docker exec -it" fails if stdin is not a terminal, e.g., when running in the background
 # "umask 0" to make downloaded artifacts, which will be saved in the shared cache as root, can be modified/deleted from the host. "exec" to keep mvn as pid 1, important for docker signal handling.
 [ "$STOP_BEFORE" = "mvn" ] && exit
-docker exec -t $DOCKER_CONTAINER sh -c "umask 0; exec ${MAVEN_CONTAINER}/bin/mvn -Dmaven.repo.local=${MAVEN_CACHE_CONTAINER} -Drat.skip=true -DskipTests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true $EXTRA_MVN_ARGS clean package" | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' | tee ${TMP_LOG}
+docker exec -t $DOCKER_CONTAINER sh -c "umask 0; exec ${MAVEN_CONTAINER}/bin/mvn -Dmaven.repo.local=${MAVEN_CACHE_CONTAINER} -Drat.skip=true -DskipTests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Danimal.sniffer.skip=true $EXTRA_MVN_ARGS clean package" | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' | tee ${TMP_LOG}
 # Some projects make files with restricted perms even if umask 0 is in force, and if --userns-remap is in force we otherwise wouldn't be able to delete them on the host afterwards.
 # Ignore "permission denied" on the top-level dir as it's owned by the host uid -- easier than trying to use wildcards to correctly get dotfiles and dotdirs.
 [ "$STOP_BEFORE" = "chmod" ] && exit

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -1,143 +1,171 @@
 [
 	{
 		"image":"eclipse-temurin:8u372-b07-jdk",
-		"name":"openjdk-8.0.372"
+		"name":"openjdk-8.0.372",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},
 	{
 		"image":"eclipse-temurin:8u342-b07-jdk",
-		"name":"openjdk-8.0.342"
+		"name":"openjdk-8.0.342",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},
 	{
 		"image":"eclipse-temurin:8u302-b08-jdk",
-		"name":"openjdk-8.0.302"
+		"name":"openjdk-8.0.302",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},	
 	{
 		"image":"openjdk:9.0.1-jdk",
-		"name":"openjdk-9.0.1"
+		"name":"openjdk-9.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=9"
 	},
 	{
 		"image":"openjdk:10.0.2-jdk",
-		"name":"openjdk-10.0.2"
+		"name":"openjdk-10.0.2",
+		"extra_mvn_args":"-Dmaven.compiler.target=10"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"openjdk-11.0.19"
+		"name":"openjdk-11.0.19",
+		"extra_mvn_args":"-Dmaven.compiler.target=11"
 	},
 	{
 		"image":"eclipse-temurin:11.0.16.1_1-jdk",
-		"name":"openjdk-11.0.16"
+		"name":"openjdk-11.0.16",
+		"extra_mvn_args":"-Dmaven.compiler.target=11"
 	},
 	{
 		"image":"eclipse-temurin:11.0.12_7-jdk",
-		"name":"openjdk-11.0.12"
+		"name":"openjdk-11.0.12",
+		"extra_mvn_args":"-Dmaven.compiler.target=11"
 	},
 	{
 		"image":"openjdk:15.0.1-jdk",
-		"name":"openjdk-15.0.1"
+		"name":"openjdk-15.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=15"
 	},
 	{
 		"image":"openjdk:16.0.1-jdk",
-		"name":"openjdk-16.0.1"
+		"name":"openjdk-16.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=16"
 	},
 	{
 		"image":"eclipse-temurin:17.0.1_12-jdk",
-		"name":"openjdk-17.0.1"
+		"name":"openjdk-17.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 
 	{
 		"image":"eclipse-temurin:17.0.4_8-jdk",
-		"name":"openjdk-17.0.4"
+		"name":"openjdk-17.0.4",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 	{
 		"image":"eclipse-temurin:17.0.7_7-jdk",
-		"name":"openjdk-17.0.7"
+		"name":"openjdk-17.0.7",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 	{
 		"image":"eclipse-temurin:18.0.2_9-jdk",
-		"name":"openjdk-18.0.2"
+		"name":"openjdk-18.0.2",
+		"extra_mvn_args":"-Dmaven.compiler.target=18"
 	},
 	{
 		"image":"eclipse-temurin:19.0.2_7-jdk",
-		"name":"openjdk-19.0.2"
+		"name":"openjdk-19.0.2",
+		"extra_mvn_args":"-Dmaven.compiler.target=19"
 	},
 	{
 		"image":"eclipse-temurin:20.0.1_9-jdk",
-		"name":"openjdk-20.0.1"
+		"name":"openjdk-20.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=20"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.12.3_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.15.1_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6",
+		"extra_mvn_args":"-Dmaven.compiler.target=9"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.24.0_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.9.0"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.9.0",
+		"extra_mvn_args":"-Dmaven.compiler.target=15"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.28.0_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.11.1"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.11.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.29.0_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.0"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.0",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.30.0_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.1"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=18"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.32.0_openjdk-11.0.19",
-		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0"
+		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0",
+		"extra_mvn_args":"-Dmaven.compiler.target=19"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:8u371-ol8-amd64",
-		"name":"oraclejdk-8.0.371"
+		"name":"oraclejdk-8.0.371",
+		"extra_mvn_args":"-Dmaven.compiler.target=8"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:11.0.19-ol8-amd64",
-		"name":"oraclejdk-11.0.19"
+		"name":"oraclejdk-11.0.19",
+		"extra_mvn_args":"-Dmaven.compiler.target=11"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:17.0.7-ol8-amd64",
-		"name":"oraclejdk-17.0.7"
+		"name":"oraclejdk-17.0.7",
+		"extra_mvn_args":"-Dmaven.compiler.target=17"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:20.0.1-ol8-amd64",
-		"name":"oraclejdk-20.0.1"
+		"name":"oraclejdk-20.0.1",
+		"extra_mvn_args":"-Dmaven.compiler.target=20"
 	},
 	{
 		"image":"eclipse-temurin:8u372-b07-jdk",
 		"name":"openjdk-nodebug-8.0.372",
-		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"openjdk-nodebug-11.0.19",
-		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=11"
 	},
 	{
 		"image":"eclipse-temurin:17.0.7_7-jdk",
 		"name":"openjdk-nodebug-17.0.7",
-		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=17"
 	},
 	{
 		"image":"eclipse-temurin:20.0.1_9-jdk",
 		"name":"openjdk-nodebug-20.0.1",
-		"extra_mvn_args":"-Dmaven.compiler.debug=false"
+		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=20"
 	}
 ]

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -2,27 +2,27 @@
 	{
 		"image":"eclipse-temurin:8u372-b07-jdk",
 		"name":"openjdk-8.0.372",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:8u342-b07-jdk",
 		"name":"openjdk-8.0.342",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:8u302-b08-jdk",
 		"name":"openjdk-8.0.302",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},	
 	{
 		"image":"openjdk:9.0.1-jdk",
 		"name":"openjdk-9.0.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=9"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.9"
 	},
 	{
 		"image":"openjdk:10.0.2-jdk",
 		"name":"openjdk-10.0.2",
-		"extra_mvn_args":"-Dmaven.compiler.target=10"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.10"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
@@ -84,19 +84,19 @@
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.12.3_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.15.1_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6",
-		"extra_mvn_args":"-Dmaven.compiler.target=9"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.9"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
@@ -131,7 +131,7 @@
 	{
 		"image":"container-registry.oracle.com/java/jdk:8u371-ol8-amd64",
 		"name":"oraclejdk-8.0.371",
-		"extra_mvn_args":"-Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:11.0.19-ol8-amd64",
@@ -151,7 +151,7 @@
 	{
 		"image":"eclipse-temurin:8u372-b07-jdk",
 		"name":"openjdk-nodebug-8.0.372",
-		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=8"
+		"extra_mvn_args":"-Dmaven.compiler.debug=false -Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",


### PR DESCRIPTION
Resolves https://github.com/binaryeq/msr24/issues/16 (hopefully). I.e., hopefully enables us to see JEP181 `NestMembers` when compiling with JDK >= 11.