### PR TITLE
Clean up aborted docker runs

### DIFF
--- a/clean-up-after-aborted-run.sh
+++ b/clean-up-after-aborted-run.sh
@@ -10,10 +10,7 @@ for c in $( docker ps -q --filter 'name=jdk-' ); do
 	docker rm $c
 done
 
-for d in $( cd worktrees && ls ); do
-	foo=${d#pid*-}
-	proj=${foo%-*.*.*}
-	fullpath=$(realpath worktrees/$d)
-	echo "Removing worktree $fullpath from project $proj..."
-	git -C $JCOMPILE_ROOT/dataset/$proj worktree remove -f "$fullpath"
+for d in worktrees/*; do
+	echo "Removing worktree $d..."
+	git -C $d worktree remove -f .		# Nice that this works
 done

--- a/clean-up-after-aborted-run.sh
+++ b/clean-up-after-aborted-run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Suitable to run after Ctrl-C-ing a docker-build-project.sh run (or make run that calls it).
+
+JCOMPILE_ROOT=$(git rev-parse --show-toplevel)
+
+for c in $( docker ps -q --filter 'name=jdk-' ); do
+	echo "Stopping and removing docker container $c..."
+	docker stop $c
+	docker rm $c
+done
+
+for d in $( cd worktrees && ls ); do
+	foo=${d#pid*-}
+	proj=${foo%-*.*.*}
+	fullpath=$(realpath worktrees/$d)
+	echo "Removing worktree $fullpath from project $proj..."
+	git -C $JCOMPILE_ROOT/dataset/$proj worktree remove -f "$fullpath"
+done


### PR DESCRIPTION
If a `docker-build-project.sh` run is aborted, e.g., with Ctrl-C, it leaves behind a git worktree and a running docker container. Manually cleaning these up was getting annoying.