### PR TITLE
Enable runs from anywhere within the repo

### DIFF
--- a/Makefile.EQ
+++ b/Makefile.EQ
@@ -1,11 +1,16 @@
+# Makefile to (re)build EQ1.tsv and its prerequisites, notably the jars under jars/EQ.
+# Run this from a subdirectory of runs/. It will produce a jars/EQ directory and EQ.tsv.
+
+JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
+
 all: EQ.tsv
 
 EQ.tsv: jars/EQ
-	( time java -cp ../../oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.SameArtifactDifferentCompilerFromDotClassOracle jars/EQ > EQ.tsv ) 2>&1 | tee make_EQ_tsv.log
+	( time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.SameArtifactDifferentCompilerFromDotClassOracle jars/EQ > $@.tsv ) 2>&1 | tee make.$@.log
 
 #TODO: Change docker-build-all.sh to create jars under jars/EQ instead of jars, so that we don't need the rename dance at the end.
 jars/EQ:
-	( time make -j 3 --output-sync -f Makefile.EQ_jars ) 2>&1 | tee make_EQ_jars.log
+	( time make -j 3 --output-sync -f $(JCOMPILE_ROOT)/Makefile.EQ_jars ) 2>&1 | tee make.EQ_jars.log
 	mv jars EQ
 	mkdir jars
 	mv EQ jars

--- a/Makefile.EQ
+++ b/Makefile.EQ
@@ -8,9 +8,5 @@ all: EQ.tsv
 EQ.tsv: jars/EQ
 	( time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.SameArtifactDifferentCompilerFromDotClassOracle jars/EQ > $@.tsv ) 2>&1 | tee make.$@.log
 
-#TODO: Change docker-build-all.sh to create jars under jars/EQ instead of jars, so that we don't need the rename dance at the end.
 jars/EQ:
 	( time make -j 3 --output-sync -f $(JCOMPILE_ROOT)/Makefile.EQ_jars ) 2>&1 | tee make.EQ_jars.log
-	mv jars EQ
-	mkdir jars
-	mv EQ jars

--- a/Makefile.EQ
+++ b/Makefile.EQ
@@ -6,7 +6,7 @@ JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
 all: EQ.tsv
 
 EQ.tsv: jars/EQ
-	( time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.SameArtifactDifferentCompilerFromDotClassOracle jars/EQ > $@.tsv ) 2>&1 | tee make.$@.log
+	( time java -cp $(JCOMPILE_ROOT)/oracle-construction/target/jcompile.jar nz.ac.wgtn.shadedetector.jcompile.oracles.SameArtifactDifferentCompilerFromDotClassOracle jars/EQ > $@ ) 2>&1 | tee make.$@.log
 
 jars/EQ:
 	( time make -j 3 --output-sync -f $(JCOMPILE_ROOT)/Makefile.EQ_jars ) 2>&1 | tee make.EQ_jars.log

--- a/Makefile.EQ_jars
+++ b/Makefile.EQ_jars
@@ -7,12 +7,14 @@
 #
 # Automatically regenerates rules to build each jar whenever dataset.json or java-compilers.json changes, by running ducker-build-all.sh --output-make-rules.
 
+JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
+
 # ALL_JAR_DONES is not filled out until after the include, but make takes the first goal as the default.
 all: all_defined_after_include
 
-generated_rules_for_all_jars.mk: dataset.json java-compilers.json docker-build-all.sh
+generated_rules_for_all_jars.mk: $(JCOMPILE_ROOT)/dataset.json $(JCOMPILE_ROOT)/java-compilers.json $(JCOMPILE_ROOT)/docker-build-all.sh
 	echo "Regenerating make rules in $@ from $^..."
-	./docker-build-all.sh --output-make-rules > $@
+	$(JCOMPILE_ROOT)/docker-build-all.sh --output-make-rules > $@
 
 # GNU make knows to regenerate this, but only when needed
 include generated_rules_for_all_jars.mk

--- a/docker-build-all.sh
+++ b/docker-build-all.sh
@@ -6,10 +6,10 @@
 
 JCOMPILE_ROOT=$(git rev-parse --show-toplevel)
 
-compilers=`cat java-compilers.json`
-#compilers=`cat java-compilers-debug.json`
-projects=`cat dataset.json`
-#projects=`cat dataset-debug.json`
+compilers=`cat $JCOMPILE_ROOT/java-compilers.json`
+#compilers=`cat $JCOMPILE_ROOT/java-compilers-debug.json`
+projects=`cat $JCOMPILE_ROOT/dataset.json`
+#projects=`cat $JCOMPILE_ROOT/dataset-debug.json`
 
 
 ECHO_IF_DRY_RUN=

--- a/docker-build-all.sh
+++ b/docker-build-all.sh
@@ -4,6 +4,8 @@
 # author jens dietrich
 
 
+JCOMPILE_ROOT=$(git rev-parse --show-toplevel)
+
 compilers=`cat java-compilers.json`
 #compilers=`cat java-compilers-debug.json`
 projects=`cat dataset.json`
@@ -23,7 +25,7 @@ then
 fi
 
 # root result folders
-JARS="jars"
+JARS="jars/EQ"
 for row in $(echo "${compilers}" | jq -r '.[] | @base64'); do
     _jq() {
      	echo "$row" | base64 --decode | jq -r "$1"
@@ -57,10 +59,10 @@ for row in $(echo "${compilers}" | jq -r '.[] | @base64'); do
 			echo "ALL_PROJECT_$PROJECT_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
 			echo "ALL_COMPILER_$CONTAINER_NAME: $JARS/$CONTAINER_NAME/$PROJECT_JAR.done"
 			echo "$JARS/$CONTAINER_NAME/$PROJECT_JAR.done:"
-			/usr/bin/echo -e '\t'./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "'$PREP_WORKTREE_CMD'" "'$EXTRA_MVN_ARGS'" '&& touch $@'
+			/usr/bin/echo -e '\t'$JCOMPILE_ROOT/docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "'$PREP_WORKTREE_CMD'" "'$EXTRA_MVN_ARGS'" '&& touch $@'
 			echo
 		else
-			$ECHO_IF_DRY_RUN sh ./docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "$SQUOTE$PREP_WORKTREE_CMD$SQUOTE" "$SQUOTE$EXTRA_MVN_ARGS$SQUOTE"
+			$ECHO_IF_DRY_RUN sh $JCOMPILE_ROOT/docker-build-project.sh ${IMAGE} ${CONTAINER_NAME} ${PROJECT_NAME} ${PROJECT_JAR} ${PROJECT_TAG} ${JARS} "$SQUOTE$PREP_WORKTREE_CMD$SQUOTE" "$SQUOTE$EXTRA_MVN_ARGS$SQUOTE"
 		fi
 	done
 	echo "# -------------------------------------"

--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -69,6 +69,7 @@ if test '!' -x "$DETECT_BYTECODE_FEATURES"; then
 	exit 1
 fi
 
+# No longer run as it's slow and we don't use the results
 DETECT_BYTECODE_FEATURES_OLDJEP181="$(pwd)/detect-bytecode-features-OLDJEP181.pl"
 if test '!' -x "$DETECT_BYTECODE_FEATURES_OLDJEP181"; then
 	echo "Cannot run $DETECT_BYTECODE_FEATURES_OLDJEP181, please ensure it is in the current directory."
@@ -145,9 +146,6 @@ if test -f "${WORKTREE_HOST}/target/${JAR_NAME}"; then
 	# Gather some additional metadata
 	( cd "${WORKTREE_HOST}" && find target/generated-sources target/generated-test-sources -type f -name '*.java' | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.generated-sources"	# Failure here creates a 0-length file, which is fine
 	( cd "${WORKTREE_HOST}" && find target -type f -name '*.class' | xargs "$DETECT_BYTECODE_FEATURES" | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.bytecode-features"
-	# Following 2 lines for cross-checking new-style detection of JEP181 'NestMembers' against old-style detection. Not used actively downstreams.
-	( cd "${WORKTREE_HOST}" && find target -type f -name '*.class' | xargs "$DETECT_BYTECODE_FEATURES_OLDJEP181" --first-digit-zero | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.bytecode-features-OLDJEP181.fdz"
-	( cd "${WORKTREE_HOST}" && find target -type f -name '*.class' | xargs "$DETECT_BYTECODE_FEATURES_OLDJEP181" --first-digit-nonzero | sort ) > "${RESULT_FOLDER}/${JAR_NAME}.bytecode-features-OLDJEP181.fdn"
 else 
 	echo "FAILURE! - copying error logs into ${RESULT_ERROR_LOG}"
 	cp ${TMP_LOG} ${RESULT_ERROR_LOG}


### PR DESCRIPTION
The current process requires running `make` from the repo root, and then moving the resulting `jars` folder into a named subfolder of `runs`. This PR makes it possible to run `make -f /path/to/Makefile.EQ` from anywhere within in the repo, which makes runs fully independent and improves automation possibilities.

Also added automatic logging of all output via `tee`, including timings.