### PR TITLE
Fix `ecj` builds

### DIFF
--- a/docker-build-project.sh
+++ b/docker-build-project.sh
@@ -96,7 +96,7 @@ mkdir -p $(dirname "${WORKTREE_HOST}")
 
 if test -n "$PREP_WORKTREE_CMD"; then
 	#( umask 0; cd "$WORKTREE_HOST"; $PREP_WORKTREE_CMD )
-	( umask 0; $PREP_WORKTREE_CMD "$WORKTREE_HOST" )
+	( umask 0; cd "$JCOMPILE_ROOT"; $PREP_WORKTREE_CMD "$WORKTREE_HOST" )
 fi
 
 MAVEN_HOST="$JCOMPILE_ROOT/apache-maven-3.9.2"

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -81,20 +81,20 @@
 		"extra_mvn_args":"-Dmaven.compiler.target=20"
 	},
 	{
-		"image":"eclipse-temurin:8u372-b07-jdk",
-		"name":"ecj-3.11.1.v20150902-1521_openjdk-8.0.372",
+		"image":"eclipse-temurin:11.0.19_7-jdk",
+		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
-		"image":"eclipse-temurin:8u372-b07-jdk",
-		"name":"ecj-3.12.3_openjdk-8.0.372",
+		"image":"eclipse-temurin:11.0.19_7-jdk",
+		"name":"ecj-3.12.3_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
-		"image":"openjdk:9.0.1-jdk",
-		"name":"ecj-3.15.1_openjdk-9.0.1",
+		"image":"eclipse-temurin:11.0.19_7-jdk",
+		"name":"ecj-3.15.1_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.9 -Dmaven.compiler.source=1.9"
 	},

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -84,49 +84,49 @@
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.12.3_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
-		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.15.1_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6",
-		"extra_mvn_args":"-Dmaven.compiler.target=1.9"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.9 -Dmaven.compiler.source=1.9"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.24.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.9.0",
-		"extra_mvn_args":"-Dmaven.compiler.target=15"
+		"extra_mvn_args":"-Dmaven.compiler.target=15 -Dmaven.compiler.source=15"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.28.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.11.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=17"
+		"extra_mvn_args":"-Dmaven.compiler.target=17 -Dmaven.compiler.source=17"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.29.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.0",
-		"extra_mvn_args":"-Dmaven.compiler.target=17"
+		"extra_mvn_args":"-Dmaven.compiler.target=17 -Dmaven.compiler.source=17"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.30.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=18"
+		"extra_mvn_args":"-Dmaven.compiler.target=18 -Dmaven.compiler.source=18"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.32.0_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0",
-		"extra_mvn_args":"-Dmaven.compiler.target=19"
+		"extra_mvn_args":"-Dmaven.compiler.target=19 -Dmaven.compiler.source=19"
 	},
 	{
 		"image":"container-registry.oracle.com/java/jdk:8u371-ol8-amd64",

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -81,50 +81,50 @@
 		"extra_mvn_args":"-Dmaven.compiler.target=20"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
+		"image":"eclipse-temurin:8u372-b07-jdk",
+		"name":"ecj-3.11.1.v20150902-1521_openjdk-8.0.372",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.12.3_openjdk-11.0.19",
+		"image":"eclipse-temurin:8u372-b07-jdk",
+		"name":"ecj-3.12.3_openjdk-8.0.372",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.15.1_openjdk-11.0.19",
+		"image":"openjdk:9.0.1-jdk",
+		"name":"ecj-3.15.1_openjdk-9.0.1",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.6",
 		"extra_mvn_args":"-Dmaven.compiler.target=1.9 -Dmaven.compiler.source=1.9"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.24.0_openjdk-11.0.19",
+		"image":"openjdk:15.0.1-jdk",
+		"name":"ecj-3.24.0_openjdk-15.0.1",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.9.0",
 		"extra_mvn_args":"-Dmaven.compiler.target=15 -Dmaven.compiler.source=15"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.28.0_openjdk-11.0.19",
+		"image":"eclipse-temurin:17.0.7_7-jdk",
+		"name":"ecj-3.28.0_openjdk-17.0.7",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.11.1",
 		"extra_mvn_args":"-Dmaven.compiler.target=17 -Dmaven.compiler.source=17"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.29.0_openjdk-11.0.19",
+		"image":"eclipse-temurin:17.0.7_7-jdk",
+		"name":"ecj-3.29.0_openjdk-17.0.7",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.0",
 		"extra_mvn_args":"-Dmaven.compiler.target=17 -Dmaven.compiler.source=17"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.30.0_openjdk-11.0.19",
+		"image":"eclipse-temurin:18.0.2_9-jdk",
+		"name":"ecj-3.30.0_openjdk-18.0.2",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.12.1",
 		"extra_mvn_args":"-Dmaven.compiler.target=18 -Dmaven.compiler.source=18"
 	},
 	{
-		"image":"eclipse-temurin:11.0.19_7-jdk",
-		"name":"ecj-3.32.0_openjdk-11.0.19",
+		"image":"eclipse-temurin:19.0.2_7-jdk",
+		"name":"ecj-3.32.0_openjdk-19.0.2",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.13.0",
 		"extra_mvn_args":"-Dmaven.compiler.target=19 -Dmaven.compiler.source=19"
 	},

--- a/java-compilers.json
+++ b/java-compilers.json
@@ -84,13 +84,13 @@
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.11.1.v20150902-1521_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.1",
-		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",
 		"name":"ecj-3.12.3_openjdk-11.0.19",
 		"prep_worktree_cmd":"./inject-ecj-compiler.pl 2.8.2",
-		"extra_mvn_args":"-Dmaven.compiler.target=1.8 -Dmaven.compiler.source=1.8"
+		"extra_mvn_args":"-Dmaven.compiler.target=1.8"
 	},
 	{
 		"image":"eclipse-temurin:11.0.19_7-jdk",


### PR DESCRIPTION
Resolves #96 insofar as it brings the build failure count down from 601 to 445, though not all the way to the previous runs (run 34)'s 406.

Comes at the cost of making `java-compilers.json` "uneven" for `ecj` compilations in 2 ways:

1. `ecj-3.11.1.v201509021`, `ecj-3.12.3` and `ecj-3.15.1` are all (still) built using the original `openjdk-11.0.19` docker image
2. `ecj-3.11.1.v201509021`, `ecj-3.12.3` lack `-Dmaven.compiler.source=$JDK_MAJOR_VERSION`, since its absence didn't cause many build failures

Will rectify both in a future, fresh run -- right now there's no time.