### PR TITLE
Automate update dataset repo

### DIFF
--- a/Makefile.UPDATE_DATASET_REPO
+++ b/Makefile.UPDATE_DATASET_REPO
@@ -8,7 +8,7 @@ endif
 
 JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
 
-update: update_EQ_jars update_tsvs
+update: update_EQ_jars update_tsvs update_supplementary
 
 update_tsvs:
 	cp EQ.tsv NEQ1.tsv $(JMUTATE_ROOT)/NEQ2.tsv $(DATASET_ROOT)
@@ -19,3 +19,13 @@ update_EQ_jars: make_hardlinks
 
 make_hardlinks:
 	#TODO: Make hardlink dir for upload to pCloud too
+
+update_supplementary: update_EQ_supplementary update_NEQ2_supplementary
+
+update_EQ_supplementary: build-failures.zip
+	mkdir -p $(DATASET_ROOT)/supplementary/EQ
+	cp -ar $< $(DATASET_ROOT)/supplementary/EQ
+
+# An actual real file target!
+build-failures.zip:
+	zip -9 $@ jars/EQ/*.*.jar.error

--- a/Makefile.UPDATE_DATASET_REPO
+++ b/Makefile.UPDATE_DATASET_REPO
@@ -12,7 +12,7 @@ update: update_EQ update_NEQ1 update_NEQ2
 
 update_EQ: update_EQ_jars update_EQ_tsv update_EQ_supplementary
 
-update_NEQ1: update_NEQ1_tsv
+update_NEQ1: update_NEQ1_tsv update_NEQ1_supplementary
 
 update_NEQ2: update_NEQ2_jars update_NEQ2_tsv update_NEQ2_supplementary
 
@@ -36,6 +36,10 @@ make_hardlinks:
 update_NEQ2_jars:
 	# NEQ2 jars no longer get uploaded to GitHub because some of them exceed the 100MB hard limit
 
+update_NEQ1_supplementary: revapi-results.zip
+	mkdir -p $(DATASET_ROOT)/supplementary/NEQ1
+	cp -ar $< $(DATASET_ROOT)/supplementary/NEQ1
+
 update_NEQ2_supplementary:
 	# There is no NEQ2 supplementary.
 
@@ -45,6 +49,9 @@ update_EQ_supplementary: build-failures.zip
 	mkdir -p $(DATASET_ROOT)/supplementary/EQ
 	cp -ar $< $(DATASET_ROOT)/supplementary/EQ
 
-# An actual real file target!
+# Actual real file targets!
 build-failures.zip:
 	zip -9 $@ jars/EQ/*/*.jar.error
+
+revapi-results.zip:
+	zip -9 $@ jars/EQ/*/*.revapi.*

--- a/Makefile.UPDATE_DATASET_REPO
+++ b/Makefile.UPDATE_DATASET_REPO
@@ -8,10 +8,23 @@ endif
 
 JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
 
-update: update_EQ_jars update_tsvs update_supplementary
+update: update_EQ update_NEQ1 update_NEQ2
 
-update_tsvs:
-	cp EQ.tsv NEQ1.tsv $(JMUTATE_ROOT)/NEQ2.tsv $(DATASET_ROOT)
+update_EQ: update_EQ_jars update_EQ_tsv update_EQ_supplementary
+
+update_NEQ1: update_NEQ1_tsv
+
+update_NEQ2: update_NEQ2_jars update_NEQ2_tsv update_NEQ2_supplementary
+
+update_EQ_tsv:
+	gzip -9 -k EQ.tsv
+	cp EQ.tsv.gz $(DATASET_ROOT)
+
+update_NEQ1_tsv:
+	cp NEQ1.tsv $(DATASET_ROOT)
+
+update_NEQ2_tsv:
+	cp $(JMUTATE_ROOT)/NEQ2.tsv $(DATASET_ROOT)
 
 update_EQ_jars: make_hardlinks
 	rm -r $(DATASET_ROOT)/jars/EQ
@@ -19,6 +32,12 @@ update_EQ_jars: make_hardlinks
 
 make_hardlinks:
 	#TODO: Make hardlink dir for upload to pCloud too
+
+update_NEQ2_jars:
+	# NEQ2 jars no longer get uploaded to GitHub because some of them exceed the 100MB hard limit
+
+update_NEQ2_supplementary:
+	# There is no NEQ2 supplementary.
 
 update_supplementary: update_EQ_supplementary update_NEQ2_supplementary
 
@@ -28,4 +47,4 @@ update_EQ_supplementary: build-failures.zip
 
 # An actual real file target!
 build-failures.zip:
-	zip -9 $@ jars/EQ/*.*.jar.error
+	zip -9 $@ jars/EQ/*/*.jar.error

--- a/Makefile.UPDATE_DATASET_REPO
+++ b/Makefile.UPDATE_DATASET_REPO
@@ -1,0 +1,21 @@
+ifndef DATASET_ROOT
+$(error You must define DATASET_ROOT.)
+endif
+
+ifndef JMUTATE_ROOT
+$(error You must define JMUTATE_ROOT.)
+endif
+
+JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
+
+update: update_EQ_jars update_tsvs
+
+update_tsvs:
+	cp EQ.tsv NEQ1.tsv $(JMUTATE_ROOT)/NEQ2.tsv $(DATASET_ROOT)
+
+update_EQ_jars: make_hardlinks
+	rm -r $(DATASET_ROOT)/jars/EQ
+	for f in hardlinks_for_pcloud_upload/dataset*/jars/EQ/*/*; do d=`dirname $${f#hardlinks_for_pcloud_upload/dataset*/}`; fullpath=`realpath $$f`; ( cd $(DATASET_ROOT) && mkdir -p $$d && cd $$d && cp -ar $$fullpath . ); done
+
+make_hardlinks:
+	#TODO: Make hardlink dir for upload to pCloud too

--- a/Makefile.UPDATE_PAPER
+++ b/Makefile.UPDATE_PAPER
@@ -4,6 +4,18 @@ ifndef PAPER_ROOT
 $(error You must define PAPER_ROOT.)
 endif
 
+ifndef DATASET_ROOT
+$(error You must define DATASET_ROOT.)
+endif
+
+ifndef JMUTATOR_ROOT
+$(error You must define JMUTATOR_ROOT.)
+endif
+
+# Make available to generation scripts
+export DATASET_ROOT
+export JMUTATOR_ROOT
+
 JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
 SCRIPTS := $(JCOMPILE_ROOT)/paper-scripts
 
@@ -14,7 +26,13 @@ TABLES := $(PAPER_ROOT)/generated/table-3.tex $(PAPER_ROOT)/generated/table-4.te
 SMALL_RESULTS := \
 	main-jar-count \
 	test-jar-count \
-	eq-record-count
+	eq-record-count \
+	total-oracle-record-count \
+	neq1-record-count \
+	neq2-jar-count \
+	neq2-record-count \
+	mutations-failing-verification-count \
+	neq3-distinct-repo-count
 
 SMALL_RESULT_FILES := $(foreach x,$(SMALL_RESULTS),$(PAPER_ROOT)/generated/$x.tex)
 
@@ -33,3 +51,16 @@ $(PAPER_ROOT)/generated/main-jar-count.tex: EQ.tsv
 $(PAPER_ROOT)/generated/test-jar-count.tex: EQ.tsv
 
 $(PAPER_ROOT)/generated/eq-record-count.tex: EQ.tsv
+
+#TODO: Currently this script changes dir to $(DATASET_ROOT) so we can't record prereqs properly :(
+$(PAPER_ROOT)/generated/eq-record-count.tex: EQ.tsv
+
+$(PAPER_ROOT)/generated/neq1-record-count.tex: NEQ1.tsv
+
+$(PAPER_ROOT)/generated/neq2-jar-count.tex: #TODO: Fix deps
+
+$(PAPER_ROOT)/generated/neq2-record-count.tex: #TODO: Needs to depend on NEQ2.tsv, which lives elsewhere. Fix deps
+
+$(PAPER_ROOT)/generated/mutations-failing-verification-count.tex: #TODO: Currently reads from $(JMUTATOR_ROOT) directly. Fix deps
+
+$(PAPER_ROOT)/generated/neq3-distinct-repo-count.tex: #TODO: Currently reads from $(DATASET_ROOT). Fix deps

--- a/Makefile.UPDATE_PAPER
+++ b/Makefile.UPDATE_PAPER
@@ -13,13 +13,21 @@ TABLES := $(PAPER_ROOT)/generated/table-3.tex $(PAPER_ROOT)/generated/table-4.te
 
 SMALL_RESULTS := \
 	main-jar-count \
-	test-jar-count
+	test-jar-count \
+	eq-record-count
 
 SMALL_RESULT_FILES := $(foreach x,$(SMALL_RESULTS),$(PAPER_ROOT)/generated/$x.tex)
 
 # Goals
 all: $(TSVS) $(TABLES) $(SMALL_RESULT_FILES)
 
-# Giving all .tsv files is conservative; some results may depend on much less.
-$(SMALL_RESULT_FILES): $(PAPER_ROOT)/generated/%.tex: $(SCRIPTS)/make.%.sh $(TSVS)
+# Every generated .tex file depends on the script used to make it. Anything else it depends on (e.g., a .tsv file) should be added as extra separate prerequisites.
+$(SMALL_RESULT_FILES): $(PAPER_ROOT)/generated/%.tex: $(SCRIPTS)/make.%.sh
+	mkdir -p `dirname $@`
 	$(SCRIPTS)/make.$*.sh > $@
+
+$(PAPER_ROOT)/generated/main-jar-count.tex: EQ.tsv
+
+$(PAPER_ROOT)/generated/test-jar-count.tex: EQ.tsv
+
+$(PAPER_ROOT)/generated/eq-record-count.tex: EQ.tsv

--- a/Makefile.UPDATE_PAPER
+++ b/Makefile.UPDATE_PAPER
@@ -21,6 +21,8 @@ SMALL_RESULT_FILES := $(foreach x,$(SMALL_RESULTS),$(PAPER_ROOT)/generated/$x.te
 # Goals
 all: $(TSVS) $(TABLES) $(SMALL_RESULT_FILES)
 
+small_results: $(SMALL_RESULT_FILES)
+
 # Every generated .tex file depends on the script used to make it. Anything else it depends on (e.g., a .tsv file) should be added as extra separate prerequisites.
 $(SMALL_RESULT_FILES): $(PAPER_ROOT)/generated/%.tex: $(SCRIPTS)/make.%.sh
 	mkdir -p `dirname $@`

--- a/Makefile.UPDATE_PAPER
+++ b/Makefile.UPDATE_PAPER
@@ -1,0 +1,25 @@
+# Master Makefile
+
+ifndef PAPER_ROOT
+$(error You must define PAPER_ROOT.)
+endif
+
+JCOMPILE_ROOT := $(shell git rev-parse --show-toplevel)
+SCRIPTS := $(JCOMPILE_ROOT)/paper-scripts
+
+TSVS := EQ.tsv NEQ1.tsv NEQ2.tsv
+
+TABLES := $(PAPER_ROOT)/generated/table-3.tex $(PAPER_ROOT)/generated/table-4.tex
+
+SMALL_RESULTS := \
+	main-jar-count \
+	test-jar-count
+
+SMALL_RESULT_FILES := $(foreach x,$(SMALL_RESULTS),$(PAPER_ROOT)/generated/$x.tex)
+
+# Goals
+all: $(TSVS) $(TABLES) $(SMALL_RESULT_FILES)
+
+# Giving all .tsv files is conservative; some results may depend on much less.
+$(SMALL_RESULT_FILES): $(PAPER_ROOT)/generated/%.tex: $(SCRIPTS)/make.%.sh $(TSVS)
+	$(SCRIPTS)/make.$*.sh > $@

--- a/paper-scripts/make.eq-record-count.sh
+++ b/paper-scripts/make.eq-record-count.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+zcat EQ.tsv.gz | tail +2 | wc -l

--- a/paper-scripts/make.eq-record-count.sh
+++ b/paper-scripts/make.eq-record-count.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
-zcat EQ.tsv.gz | tail +2 | wc -l
+#!/bin/bash
+printf "%'d" $(zcat EQ.tsv.gz | tail +2 | wc -l)

--- a/paper-scripts/make.main-jar-count.sh
+++ b/paper-scripts/make.main-jar-count.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-find jars/EQ -name '*.jar' | grep -v -- '-test\.jar$' | wc -l
+find jars/EQ -name '*.jar' | grep -v -- '-tests\.jar$' | wc -l

--- a/paper-scripts/make.main-jar-count.sh
+++ b/paper-scripts/make.main-jar-count.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
-find jars/EQ -name '*.jar' | grep -v -- '-tests\.jar$' | wc -l
+#!/bin/bash
+printf "%'d" $(find jars/EQ -name '*.jar' | grep -v -- '-tests\.jar$' | wc -l)

--- a/paper-scripts/make.main-jar-count.sh
+++ b/paper-scripts/make.main-jar-count.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+find jars/EQ -name '*.jar' | grep -v -- '-test\.jar$' | wc -l

--- a/paper-scripts/make.mutations-failing-verification-count.sh
+++ b/paper-scripts/make.mutations-failing-verification-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(cd $JMUTATOR_ROOT && grep '^verification failed ' jars/NEQ2/openjdk-11.0.19/*.stdout|wc -l)

--- a/paper-scripts/make.neq1-record-count.sh
+++ b/paper-scripts/make.neq1-record-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(wc -l NEQ1.tsv | perl -lne 'print $_ - 1')

--- a/paper-scripts/make.neq2-jar-count.sh
+++ b/paper-scripts/make.neq2-jar-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(ls $JMUTATOR_ROOT/jars/EQ/openjdk-11.0.19/|wc -l)

--- a/paper-scripts/make.neq2-record-count.sh
+++ b/paper-scripts/make.neq2-record-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(cd $DATASET_ROOT && wc -l NEQ2.tsv | perl -lne 'print $_ - 1')

--- a/paper-scripts/make.neq3-distinct-repo-count.sh
+++ b/paper-scripts/make.neq3-distinct-repo-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(cd $DATASET_ROOT && cut -f 10 NEQ3.tsv|sort -u|wc -l|perl -lne 'print $_ - 1')

--- a/paper-scripts/make.test-jar-count.sh
+++ b/paper-scripts/make.test-jar-count.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+find jars/EQ -name '*-test.jar' | wc -l

--- a/paper-scripts/make.test-jar-count.sh
+++ b/paper-scripts/make.test-jar-count.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
-find jars/EQ -name '*-tests.jar' | wc -l
+#!/bin/bash
+printf "%'d" $(find jars/EQ -name '*-tests.jar' | wc -l)

--- a/paper-scripts/make.test-jar-count.sh
+++ b/paper-scripts/make.test-jar-count.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-find jars/EQ -name '*-test.jar' | wc -l
+find jars/EQ -name '*-tests.jar' | wc -l

--- a/paper-scripts/make.total-oracle-record-count.sh
+++ b/paper-scripts/make.total-oracle-record-count.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf "%'d" $(cd $DATASET_ROOT && zcat EQ.tsv.gz | wc -l - NEQ[123].tsv | perl -lne 'print $1 - 4 if /(\d+) total/')


### PR DESCRIPTION
Adds:

- A Makefile to update the [`dataset` repo](https://github.com/binaryeq/dataset) (mostly -- doesn't do any git operations)
- A Makefile to generate results (e.g., numbers, but any LaTeX should work) into `.tex` files under `$PAPER_ROOT/generated` using scripts in `paper-scripts` in this repo, useful for keeping numbers in [the paper](https://github.com/binaryeq/msr24) up-to-date
- Some scripts for the above Makefile to use

Arguably these scripts and Makefiles should be distributed differently between the repos... But I think it's best to have them all in one place, and it might as well be here.

TODO: There are quite a few missing dependencies in the `paper-scripts` scripts -- e.g., some assume that everything has already been copied into the local `dataset` repo by the first Makefile.